### PR TITLE
Add camera restart logging, restart on main thread

### DIFF
--- a/vision_app/app/build.gradle
+++ b/vision_app/app/build.gradle
@@ -12,11 +12,11 @@ buildscript {
 }
 
 dependencies {
-    compile "com.android.support:support-v4:23.1.0"
-    compile "com.android.support:support-v13:23.1.0"
+    compile "com.android.support:support-v4:23.4.0"
+    compile "com.android.support:support-v13:23.4.0"
     compile project(':openCVLibrary310')
-    compile 'com.android.support:appcompat-v7:23.0.0'
-    compile 'com.android.support:design:23.0.0'
+    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:design:23.4.0'
     compile 'org.florescu.android.rangeseekbar:rangeseekbar-library:0.3.0'
 }
 

--- a/vision_app/app/build.gradle
+++ b/vision_app/app/build.gradle
@@ -18,6 +18,10 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'com.android.support:design:23.4.0'
     compile 'org.florescu.android.rangeseekbar:rangeseekbar-library:0.3.0'
+
+    compile 'org.slf4j:slf4j-api:1.7.21'
+    compile 'com.github.tony19:logback-android-core:1.1.1-6'
+    compile 'com.github.tony19:logback-android-classic:1.1.1-6'
 }
 
 android {

--- a/vision_app/app/src/main/AndroidManifest.xml
+++ b/vision_app/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:name=".AppContext"

--- a/vision_app/app/src/main/assets/logback.xml
+++ b/vision_app/app/src/main/assets/logback.xml
@@ -1,0 +1,32 @@
+<configuration>
+    <property name="LOG_DIR" value="/storage/emulated/0/Download/" />
+
+    <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/log-latest.html</file>
+
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <charset>UTF-8</charset>
+            <layout class="ch.qos.logback.classic.html.HTMLLayout">
+                <pattern>%d{HH:mm:ss.SSS}%thread%level%line%msg</pattern>
+            </layout>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- daily rollover -->
+            <fileNamePattern>${LOG_DIR}/log.%d{yyyy-MM-dd}.%i.html</fileNamePattern>
+
+            <timeBasedFileNamingAndTriggeringPolicy
+                class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <!-- or whenever the file size reaches 5MB -->
+                <maxFileSize>5MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+
+            <!-- keep 30 days' worth of history -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="ROLLING" />
+    </root>
+</configuration>

--- a/vision_app/app/src/main/java/com/team254/cheezdroid/VisionTrackerActivity.java
+++ b/vision_app/app/src/main/java/com/team254/cheezdroid/VisionTrackerActivity.java
@@ -7,13 +7,19 @@ import android.app.Dialog;
 import android.app.DialogFragment;
 import android.app.Fragment;
 import android.app.admin.DevicePolicyManager;
-import android.content.*;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.media.MediaPlayer;
 import android.os.BatteryManager;
 import android.os.Bundle;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.util.Pair;
@@ -33,9 +39,7 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.support.v4.app.ActivityCompat;
 
-import com.team254.cheezdroid.comm.RobotConnection;
 import com.team254.cheezdroid.comm.RobotConnectionStateListener;
 import com.team254.cheezdroid.comm.RobotConnectionStatusBroadcastReceiver;
 
@@ -46,6 +50,8 @@ import java.util.TimerTask;
 
 public class VisionTrackerActivity extends Activity implements RobotConnectionStateListener, RobotEventListener {
     private static final int REQUEST_CAMERA_PERMISSION = 1;
+    private static final String[] PERMISSIONS =
+            new String[]{Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE};
     private static final String FRAGMENT_DIALOG = "dialog";
 
     private static boolean sLocked = true;
@@ -125,8 +131,7 @@ public class VisionTrackerActivity extends Activity implements RobotConnectionSt
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             ActivityCompat.requestPermissions(parent.getActivity(),
-                                    new String[]{Manifest.permission.CAMERA},
-                                    REQUEST_CAMERA_PERMISSION);
+                                    PERMISSIONS, REQUEST_CAMERA_PERMISSION);
                         }
                     })
                     .setNegativeButton(android.R.string.cancel,
@@ -171,12 +176,11 @@ public class VisionTrackerActivity extends Activity implements RobotConnectionSt
 
     }
 
-    private void requestCameraPermission() {
+    private void requestPermissions() {
         if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.CAMERA)) {
             new ConfirmationDialog().show(this.getFragmentManager(), FRAGMENT_DIALOG);
         } else {
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.CAMERA},
-                    REQUEST_CAMERA_PERMISSION);
+            ActivityCompat.requestPermissions(this, PERMISSIONS, REQUEST_CAMERA_PERMISSION);
         }
     }
 
@@ -274,10 +278,11 @@ public class VisionTrackerActivity extends Activity implements RobotConnectionSt
     }
 
     private void tryStartCamera() {
-        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.CAMERA)
-                != PackageManager.PERMISSION_GRANTED) {
-            requestCameraPermission();
-            return;
+        for (String permission : PERMISSIONS) {
+            if (ActivityCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED) {
+                requestPermissions();
+                return;
+            }
         }
         mView = (VisionTrackerGLSurfaceView) findViewById(R.id.my_gl_surface_view);
         mView.setCameraTextureListener(mView);

--- a/vision_app/app/src/main/java/org/opencv/android/BetterCameraGLRendererBase.java
+++ b/vision_app/app/src/main/java/org/opencv/android/BetterCameraGLRendererBase.java
@@ -12,6 +12,9 @@ import android.opengl.GLSurfaceView;
 import android.util.Log;
 import android.view.View;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
@@ -96,6 +99,8 @@ public abstract class BetterCameraGLRendererBase implements GLSurfaceView.Render
 
     protected BetterCameraGLSurfaceView mView;
 
+    private final Logger mLogger;
+
     protected abstract void openCamera(int id);
 
     protected abstract void closeCamera();
@@ -128,10 +133,10 @@ public abstract class BetterCameraGLRendererBase implements GLSurfaceView.Render
             if (actualExposure == null) {
                 return;
             }
-            if (actualExposure > 1000000L) {
-                Log.d("BRIGHT", "exposure was out of range " + result.get(CaptureResult.SENSOR_EXPOSURE_TIME));
+            if (true || actualExposure > 1000000L) {
+                mLogger.debug("exposure was out of range " + result.get(CaptureResult.SENSOR_EXPOSURE_TIME));
                 if (System.currentTimeMillis() - mLastRestartTimestamp > TimeUnit.SECONDS.toMillis(4)) {
-                    Log.d("BRIGHT", "restarting");
+                    mLogger.debug("restarting camera");
                     mLastRestartTimestamp = System.currentTimeMillis();
                     setCameraIndex(-1);
                 }
@@ -149,6 +154,7 @@ public abstract class BetterCameraGLRendererBase implements GLSurfaceView.Render
         vert.put(vertices).position(0);
         texOES.put(texCoordOES).position(0);
         tex2D.put(texCoord2D).position(0);
+        mLogger = LoggerFactory.getLogger(BetterCameraGLRendererBase.class);
     }
 
     @Override


### PR DESCRIPTION
This logs to an HTML file in ~/Downloads (requires external storage permissions). Logs will be kept continuously for 30 days or until log file exceeds 5MB. Right now the only thing we're logging to file are the two messages when we detect an improper exposure value and then trigger the restart. 